### PR TITLE
Forcing a version of addressable

### DIFF
--- a/tlaw.gemspec
+++ b/tlaw.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_runtime_dependency 'faraday'
-  s.add_runtime_dependency 'addressable'
+  s.add_runtime_dependency 'addressable', '~> 2.4.0'
   s.add_runtime_dependency 'crack'
 
   # Managing everything


### PR DESCRIPTION
I couldn't get the gem to load while I had an old version of addressable in the Gemfile.lock.  Once I forced it to up to 2.4.0 it worked.  It was 2.3.6