### PR TITLE
Accept string namespace/endpoint

### DIFF
--- a/lib/tlaw/dsl/namespace_wrapper.rb
+++ b/lib/tlaw/dsl/namespace_wrapper.rb
@@ -8,11 +8,13 @@ module TLAW
   module DSL
     class NamespaceWrapper < BaseWrapper
       def endpoint(name, path = nil, **opts, &block)
+        name = name.to_sym
         update_existing(Endpoint, name, path, **opts, &block) ||
           add_child(Endpoint, name, path: path || "/#{name}", **opts, &block)
       end
 
       def namespace(name, path = nil, &block)
+        name = name.to_sym
         update_existing(Namespace, name, path, &block) ||
           add_child(Namespace, name, path: path || "/#{name}", &block)
       end

--- a/spec/tlaw/dsl_spec.rb
+++ b/spec/tlaw/dsl_spec.rb
@@ -115,6 +115,12 @@ module TLAW
           }
           its(:'param_set.names') { is_expected.to include(:bar, :baz, :quux) }
         end
+
+        context 'given a string name' do
+          before { wrapper.send(definer, 'ep1') }
+
+          its(:symbol) { is_expected.to eq :ep1 }
+        end
       end
 
       describe '#endpoint' do


### PR DESCRIPTION
It's clearly recommended to pass symbol names for namespaces/endpoints, but string argument currently half work and lead to strange error messages:

    namespace 'my_namespace' { ... }

    api.my_namespace # => ArgumentError: Unregistered tlaw::namespace: my_namespace

Since Ruby typically string arguments instead of symbols (e.g. `define_method`, `const_get`), I'd recommend accepting string arguments.

This patches implements it.