### PR TITLE
Change {Namespace/Endpoint}.inspect to match Ruby conventions

### DIFF
--- a/lib/tlaw/endpoint.rb
+++ b/lib/tlaw/endpoint.rb
@@ -29,8 +29,8 @@ module TLAW
       # # => <SomeApi::SomeNamespace::MyEndpoint call-sequence: my_endpoint(param1, param2: nil), docs: .describe>
       # ```
       def inspect
-        "#<#{name || '(unnamed endpoint class)'}:" \
-        " call-sequence: #{symbol}(#{param_set.to_code}); docs: .describe>"
+        "#{name || '(unnamed endpoint class)'}(" \
+        "call-sequence: #{symbol}(#{param_set.to_code}); docs: .describe)"
       end
 
       # @private

--- a/lib/tlaw/namespace.rb
+++ b/lib/tlaw/namespace.rb
@@ -61,14 +61,14 @@ module TLAW
       end
 
       def inspect
-        "#<#{name || '(unnamed namespace class)'}: " \
+        "#{name || '(unnamed namespace class)'}(" \
         "call-sequence: #{symbol}(#{param_set.to_code});" +
-          inspect_docs
+          inspect_docs + ')'
       end
 
       # @private
       def inspect_docs
-        inspect_namespaces + inspect_endpoints + ' docs: .describe>'
+        inspect_namespaces + inspect_endpoints + ' docs: .describe'
       end
 
       # @private
@@ -137,7 +137,7 @@ module TLAW
 
     def inspect
       "#<#{symbol}(#{param_set.to_hash_code(@parent_params)})" +
-        self.class.inspect_docs
+        self.class.inspect_docs + '>'
     end
 
     def describe

--- a/spec/tlaw/api_spec.rb
+++ b/spec/tlaw/api_spec.rb
@@ -37,7 +37,7 @@ module TLAW
       context '.inspect' do
         subject { api_class.inspect }
 
-        it { is_expected.to eq '#<Dummy: call-sequence: Dummy.new(api_key:); namespaces: some_ns; endpoints: some_ep; docs: .describe>' }
+        it { is_expected.to eq 'Dummy(call-sequence: Dummy.new(api_key:); namespaces: some_ns; endpoints: some_ep; docs: .describe)' }
       end
 
       context '#inspect' do

--- a/spec/tlaw/endpoint_spec.rb
+++ b/spec/tlaw/endpoint_spec.rb
@@ -173,7 +173,7 @@ module TLAW
       describe '#inspect' do
         subject { endpoint.inspect }
 
-        it { is_expected.to eq '#<SomeEndpoint: call-sequence: ep(arg3, arg1=nil, kv2:, kv1: nil); docs: .describe>' }
+        it { is_expected.to eq 'SomeEndpoint(call-sequence: ep(arg3, arg1=nil, kv2:, kv1: nil); docs: .describe)' }
       end
 
       describe '#describe' do

--- a/spec/tlaw/namespace_spec.rb
+++ b/spec/tlaw/namespace_spec.rb
@@ -150,7 +150,7 @@ module TLAW
         describe '.inspect' do
           subject { namespace_class.inspect }
 
-          it { is_expected.to eq '#<SomeNamespace: call-sequence: some_ns(apikey: nil); namespaces: child_ns; endpoints: some_ep; docs: .describe>' }
+          it { is_expected.to eq 'SomeNamespace(call-sequence: some_ns(apikey: nil); namespaces: child_ns; endpoints: some_ep; docs: .describe)' }
         end
 
         describe '#inspect' do


### PR DESCRIPTION
I was very confused at first when debugging with `tlaw` because it doesn't follow Ruby conventions for class names.

The expression "#<SomeClassName...>" is normally used for singleton classes:

```
Symbol.inspect # => "Symbol" 
Symbol.singleton_class.inspect # => "#<Class:Symbol>" 
```

I'd recommend using Rails convention `"SomeClassName(extra info)"` instead:

```
class User < ActiveRecord::Base; end
User.inspect # => "User(id: integer, email: string, ...)"
```

This PR changes that accordingly. It only modifies the class level method `inspect`, not the instance method.