### PR TITLE
Keyword argument passing

### DIFF
--- a/lib/tlaw/dsl/base_wrapper.rb
+++ b/lib/tlaw/dsl/base_wrapper.rb
@@ -27,7 +27,7 @@ module TLAW
       end
 
       def param(name, type = nil, **opts)
-        @object.param_set.add(name, **opts.merge(type: type))
+        @object.param_set.add(name, **opts, type: type)
       end
 
       def post_process(key = nil, &block)

--- a/lib/tlaw/endpoint.rb
+++ b/lib/tlaw/endpoint.rb
@@ -36,7 +36,7 @@ module TLAW
       # @private
       def to_code
         "def #{to_method_definition}\n" \
-        "  child(:#{symbol}, Endpoint).call({#{param_set.to_hash_code}})\n" \
+        "  child(:#{symbol}, Endpoint).call(#{param_set.to_hash_code})\n" \
         'end'
       end
 

--- a/lib/tlaw/namespace.rb
+++ b/lib/tlaw/namespace.rb
@@ -156,7 +156,7 @@ module TLAW
             fail ArgumentError,
                  "Unregistered #{expected_class.name.downcase}: #{symbol}"
         end
-        .new(@parent_params.merge(params))
+        .new(**@parent_params, **params)
     end
   end
 end

--- a/lib/tlaw/namespace.rb
+++ b/lib/tlaw/namespace.rb
@@ -56,7 +56,7 @@ module TLAW
       # @private
       def to_code
         "def #{to_method_definition}\n" \
-        "  child(:#{symbol}, Namespace, {#{param_set.to_hash_code}})\n" \
+        "  child(:#{symbol}, Namespace, #{param_set.to_hash_code})\n" \
         'end'
       end
 

--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -31,7 +31,7 @@ module TLAW
       end
 
       def merge(**new_options)
-        Params.make(name, @options.merge(new_options))
+        Params.make(name, **@options, **new_options)
       end
 
       def field

--- a/spec/tlaw/endpoint_spec.rb
+++ b/spec/tlaw/endpoint_spec.rb
@@ -13,7 +13,7 @@ module TLAW
     describe '#construct_url' do
       let(:params) { {} }
 
-      subject(:url) { endpoint.__send__(:construct_url, params) }
+      subject(:url) { endpoint.__send__(:construct_url, **params) }
 
       context 'no params' do
         it { is_expected.to eq 'https://api.example.com/' }

--- a/spec/tlaw/endpoint_spec.rb
+++ b/spec/tlaw/endpoint_spec.rb
@@ -152,7 +152,7 @@ module TLAW
 
       it { is_expected
         .to  include('def ep(arg3, arg1=nil, arg2="foo", kv2:, kv1: nil, kv3: 14)')
-        .and include('.call({kv1: kv1, kv2: kv2, kv3: kv3, arg1: arg1, arg2: arg2, arg3: arg3})')
+        .and include('.call(kv1: kv1, kv2: kv2, kv3: kv3, arg1: arg1, arg2: arg2, arg3: arg3)')
       }
     end
 

--- a/spec/tlaw/namespace_spec.rb
+++ b/spec/tlaw/namespace_spec.rb
@@ -63,7 +63,7 @@ module TLAW
 
         it { is_expected.to eq(%{
           |def some_ns(apikey: nil)
-          |  child(:some_ns, Namespace, {apikey: apikey})
+          |  child(:some_ns, Namespace, apikey: apikey)
           |end
         }.unindent)}
       end

--- a/spec/tlaw/namespace_spec.rb
+++ b/spec/tlaw/namespace_spec.rb
@@ -120,7 +120,7 @@ module TLAW
       }
       let(:initial_params) { {} }
 
-      subject(:namespace) { namespace_class.new(initial_params) }
+      subject(:namespace) { namespace_class.new(**initial_params) }
 
       describe '#<endpoint>' do
         let(:endpoint) { instance_double(endpoint_class, call: nil) }


### PR DESCRIPTION
It's probably because I've spent too much time on the ruby-core discussion about keyword arguments, but I noticed that the code could be simplified and/or made more explicit about keyword arguments.