### PR TITLE
Parent & al.

### DIFF
--- a/lib/tlaw/api_path.rb
+++ b/lib/tlaw/api_path.rb
@@ -120,9 +120,12 @@ module TLAW
       end
     end
 
+    attr_reader :parent
+
     extend Forwardable
 
-    def initialize(**parent_params)
+    def initialize(parent = nil, **parent_params)
+      @parent = parent
       @parent_params = parent_params
     end
 

--- a/lib/tlaw/api_path.rb
+++ b/lib/tlaw/api_path.rb
@@ -1,4 +1,5 @@
 require_relative 'params/set'
+require_relative 'has_parent'
 require 'forwardable'
 
 module TLAW
@@ -7,11 +8,12 @@ module TLAW
   #
   class APIPath
     class << self
+      include HasParent
       # @private
       attr_accessor :base_url, :path, :xml, :docs_link
 
       # @private
-      attr_reader :symbol, :parent
+      attr_reader :symbol
 
       # @private
       CLASS_NAMES = {
@@ -120,7 +122,7 @@ module TLAW
       end
     end
 
-    attr_reader :parent
+    include HasParent
 
     extend Forwardable
 

--- a/lib/tlaw/api_path.rb
+++ b/lib/tlaw/api_path.rb
@@ -11,7 +11,7 @@ module TLAW
       attr_accessor :base_url, :path, :xml, :docs_link
 
       # @private
-      attr_reader :symbol
+      attr_reader :symbol, :parent
 
       # @private
       CLASS_NAMES = {
@@ -57,9 +57,10 @@ module TLAW
       end
 
       # @private
-      def setup_parents(parent)
+      def parent=(parent)
         param_set.parent = parent.param_set
         response_processor.parent = parent.response_processor
+        @parent = parent
       end
 
       # @private

--- a/lib/tlaw/dsl/namespace_wrapper.rb
+++ b/lib/tlaw/dsl/namespace_wrapper.rb
@@ -40,7 +40,7 @@ module TLAW
       def add_child(child_class, name, **opts, &block)
         @object.add_child(
           child_class.inherit(@object, symbol: name, **opts)
-          .tap { |c| c.setup_parents(@object) }
+          .tap { |c| c.parent = @object }
           .tap(&:params_from_path!)
           .tap { |c|
             WRAPPERS[child_class].new(c).define(&block) if block

--- a/lib/tlaw/endpoint.rb
+++ b/lib/tlaw/endpoint.rb
@@ -75,7 +75,7 @@ module TLAW
     #
     # Params defined in parent namespace are passed here.
     #
-    def initialize(**parent_params)
+    def initialize(parent = nil, **parent_params)
       super
 
       @client = Faraday.new do |faraday|

--- a/lib/tlaw/has_parent.rb
+++ b/lib/tlaw/has_parent.rb
@@ -1,0 +1,15 @@
+module TLAW
+  module HasParent
+    attr_reader :parent
+
+    # Returns [parent, parent.parent, ...]
+    def parents
+      result = []
+      cursor = self
+      while (cursor = cursor.parent)
+        result << cursor
+      end
+      result
+    end
+  end
+end

--- a/lib/tlaw/namespace.rb
+++ b/lib/tlaw/namespace.rb
@@ -156,7 +156,7 @@ module TLAW
             fail ArgumentError,
                  "Unregistered #{expected_class.name.downcase}: #{symbol}"
         end
-        .new(**@parent_params, **params)
+        .new(self, **@parent_params, **params)
     end
   end
 end

--- a/lib/tlaw/namespace.rb
+++ b/lib/tlaw/namespace.rb
@@ -39,6 +39,22 @@ module TLAW
         end
       end
 
+      RESTRICTION = {
+        endpoints: Endpoint,
+        namespaces: Namespace,
+        nil => APIPath
+      }.freeze
+
+      def traverse(restrict_to = nil, &block)
+        return to_enum(:traverse, restrict_to) unless block_given?
+        klass = RESTRICTION.fetch(restrict_to)
+        children.each do |_, child|
+          yield child if child < klass
+          child.traverse(restrict_to, &block) if child.respond_to?(:traverse)
+        end
+        self
+      end
+
       # Lists all current namespace's nested namespaces as a hash.
       #
       # @return [Hash{Symbol => Namespace}]

--- a/spec/tlaw/api_spec.rb
+++ b/spec/tlaw/api_spec.rb
@@ -1,9 +1,26 @@
 module TLAW
   describe API do
+    let(:api_class) {
+      Class.new(API) do
+        define do
+          base 'http://api.example.com'
+
+          param :api_key, required: true
+
+          endpoint :some_ep do
+            param :foo
+          end
+
+          namespace :some_ns do
+            endpoint :other_ep
+          end
+        end
+      end
+    }
+
     context '.define' do
       let(:block) { -> {} }
       let(:wrapper) { instance_double('TLAW::DSL::APIWrapper', define: nil) }
-      let(:api_class) { Class.new(described_class) }
 
       subject { api_class.define(&block) }
 
@@ -14,22 +31,6 @@ module TLAW
     end
 
     context 'documentation' do
-      let(:api_class) {
-        Class.new(API) do
-          define do
-            base 'http://api.example.com'
-
-            param :api_key, required: true
-
-            endpoint :some_ep do
-              param :foo
-            end
-
-            namespace :some_ns do
-            end
-          end
-        end
-      }
       let(:api) { api_class.new(api_key: '123') }
 
       before { allow(api_class).to receive(:name).and_return('Dummy') }

--- a/spec/tlaw/api_spec.rb
+++ b/spec/tlaw/api_spec.rb
@@ -75,5 +75,33 @@ module TLAW
         it { is_expected.to eq api_class::SomeNs }
       end
     end
+
+    describe '.parents' do
+      subject { klass.parents }
+
+      describe 'for a top level class' do
+        let(:klass) { api_class }
+
+        it { is_expected.to eq [] }
+      end
+
+      describe 'for a sub namespace' do
+        let(:klass) { api_class::SomeNs }
+
+        it { is_expected.to eq [api_class] }
+      end
+
+      describe 'for a sub endpoint' do
+        let(:klass) { api_class::SomeEp }
+
+        it { is_expected.to eq [api_class] }
+      end
+
+      describe 'for a sub sub endpoint' do
+        let(:klass) { api_class::SomeNs::OtherEp }
+
+        it { is_expected.to eq [api_class::SomeNs, api_class] }
+      end
+    end
   end
 end

--- a/spec/tlaw/api_spec.rb
+++ b/spec/tlaw/api_spec.rb
@@ -47,5 +47,33 @@ module TLAW
         it { is_expected.to eq '#<Dummy.new(api_key: "123") namespaces: some_ns; endpoints: some_ep; docs: .describe>' }
       end
     end
+
+    describe '.parent' do
+      subject { klass.parent }
+
+      describe 'for a top level class' do
+        let(:klass) { api_class }
+
+        it { is_expected.to be_nil }
+      end
+
+      describe 'for a sub namespace' do
+        let(:klass) { api_class::SomeNs }
+
+        it { is_expected.to eq api_class }
+      end
+
+      describe 'for a sub endpoint' do
+        let(:klass) { api_class::SomeEp }
+
+        it { is_expected.to eq api_class }
+      end
+
+      describe 'for a sub sub endpoint' do
+        let(:klass) { api_class::SomeNs::OtherEp }
+
+        it { is_expected.to eq api_class::SomeNs }
+      end
+    end
   end
 end

--- a/spec/tlaw/dsl_spec.rb
+++ b/spec/tlaw/dsl_spec.rb
@@ -78,6 +78,7 @@ module TLAW
           its(:path) { is_expected.to eq '/ep1' }
           its(:name) { is_expected.to eq 'Ns::Ep1' }
           its(:parent) { is_expected.to eq Ns }
+          its(:parents) { is_expected.to eq [Ns] }
           its(:base_url) { is_expected.to eq 'https://api.example.com/ep1' }
           its(:'param_set.parent') { is_expected.to eq namespace.param_set }
           its(:'response_processor.parent') { is_expected.to eq namespace.response_processor }

--- a/spec/tlaw/dsl_spec.rb
+++ b/spec/tlaw/dsl_spec.rb
@@ -77,6 +77,7 @@ module TLAW
           its(:symbol) { is_expected.to eq :ep1 }
           its(:path) { is_expected.to eq '/ep1' }
           its(:name) { is_expected.to eq 'Ns::Ep1' }
+          its(:parent) { is_expected.to eq Ns }
           its(:base_url) { is_expected.to eq 'https://api.example.com/ep1' }
           its(:'param_set.parent') { is_expected.to eq namespace.param_set }
           its(:'response_processor.parent') { is_expected.to eq namespace.response_processor }

--- a/spec/tlaw/namespace_spec.rb
+++ b/spec/tlaw/namespace_spec.rb
@@ -138,10 +138,18 @@ module TLAW
 
           its_block do
             is_expected
-              .to send_message(endpoint_class, :new).with(apikey: 'foo').returning(endpoint)
+              .to send_message(endpoint_class, :new).with(namespace, apikey: 'foo').returning(endpoint)
               .and send_message(endpoint, :call).with(foo: 'bar')
           end
         end
+      end
+
+      describe '#<namespace>' do
+        subject { namespace.child_ns }
+
+        its(:class) { is_expected.to eq child_class }
+
+        its(:parent) { is_expected.to eq namespace }
       end
 
       context 'documentation' do

--- a/spec/tlaw/namespace_spec.rb
+++ b/spec/tlaw/namespace_spec.rb
@@ -145,11 +145,15 @@ module TLAW
       end
 
       describe '#<namespace>' do
-        subject { namespace.child_ns }
+        let(:child_instance) { namespace.child_ns }
+
+        subject { child_instance }
 
         its(:class) { is_expected.to eq child_class }
 
         its(:parent) { is_expected.to eq namespace }
+
+        its(:parents) { is_expected.to eq [namespace] }
       end
 
       context 'documentation' do


### PR DESCRIPTION
This PR fixes #12 by adding:
  * `parent`, `parents` & `lineage` as instance and singleton methods to `APIPath`
  * `Namespace.traverse`

It builds on [#15], but doesn't really depend on it.