### PR TITLE
Call sequence

### DIFF
--- a/lib/tlaw/api_path.rb
+++ b/lib/tlaw/api_path.rb
@@ -80,7 +80,12 @@ module TLAW
 
       # @private
       def to_method_definition
-        "#{name_to_call}(#{param_set.to_code})"
+        params = param_set.to_code
+        if params.empty?
+          name_to_call.to_s
+        else
+          "#{name_to_call}(#{params})"
+        end
       end
 
       # @private

--- a/lib/tlaw/api_path.rb
+++ b/lib/tlaw/api_path.rb
@@ -80,8 +80,11 @@ module TLAW
 
       # @private
       def to_method_definition
-        "#{symbol}(#{param_set.to_code})"
+        "#{name_to_call}(#{param_set.to_code})"
       end
+
+      # @private
+      alias_method :name_to_call, :symbol
 
       # Redefined on descendants, it just allows you to do `api.namespace.describe`
       # or `api.namespace1.namespace2.endpoints[:my_endpoint].describe`

--- a/lib/tlaw/endpoint.rb
+++ b/lib/tlaw/endpoint.rb
@@ -30,7 +30,7 @@ module TLAW
       # ```
       def inspect
         "#{name || '(unnamed endpoint class)'}(" \
-        "call-sequence: #{symbol}(#{param_set.to_code}); docs: .describe)"
+        "call-sequence: #{to_method_definition}; docs: .describe)"
       end
 
       # @private

--- a/lib/tlaw/namespace.rb
+++ b/lib/tlaw/namespace.rb
@@ -62,7 +62,7 @@ module TLAW
 
       def inspect
         "#{name || '(unnamed namespace class)'}(" \
-        "call-sequence: #{name_to_call}(#{param_set.to_code});" +
+        "call-sequence: #{to_method_definition};" +
           inspect_docs + ')'
       end
 

--- a/lib/tlaw/namespace.rb
+++ b/lib/tlaw/namespace.rb
@@ -67,9 +67,6 @@ module TLAW
       end
 
       # @private
-      alias_method :name_to_call, :symbol
-
-      # @private
       def inspect_docs
         inspect_namespaces + inspect_endpoints + ' docs: .describe'
       end

--- a/spec/tlaw/namespace_spec.rb
+++ b/spec/tlaw/namespace_spec.rb
@@ -84,7 +84,7 @@ module TLAW
           |
           |  Namespaces:
           |
-          |  .child_ns()
+          |  .child_ns
           |
           |  Endpoints:
           |
@@ -176,7 +176,7 @@ module TLAW
             |
             |  Namespaces:
             |
-            |  .child_ns()
+            |  .child_ns
             |
             |  Endpoints:
             |


### PR DESCRIPTION
A simple PR that simplifies a bit the definition of `inspect` and also remove the empty `()` when there are no params.