### PR TITLE
Type refactor

### DIFF
--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -62,7 +62,7 @@ module TLAW
           name,
           ("[#{doc_type}]" if doc_type),
           description,
-          ("\n  Possible values: #{type.possible_values}" if @options[:enum]),
+          ("\n  Possible values: #{type.possible_values}" if type.respond_to?(:possible_values)),
           ("(default = #{default.inspect})" if default)
         ].compact
           .join(' ')

--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -62,7 +62,7 @@ module TLAW
           name,
           ("[#{doc_type}]" if doc_type),
           description,
-          ("\n  Possible values: #{type.values.map(&:inspect).join(', ')}" if @options[:enum]),
+          ("\n  Possible values: #{type.values}" if @options[:enum]),
           ("(default = #{default.inspect})" if default)
         ].compact
           .join(' ')

--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -62,7 +62,7 @@ module TLAW
           name,
           ("[#{doc_type}]" if doc_type),
           description,
-          ("\n  Possible values: #{type.values}" if @options[:enum]),
+          ("\n  Possible values: #{type.possible_values}" if @options[:enum]),
           ("(default = #{default.inspect})" if default)
         ].compact
           .join(' ')

--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -12,7 +12,7 @@ module TLAW
       def initialize(name, **options)
         @name = name
         @options = options
-        @type = Type.parse(options)
+        @type = Type.parse(**options)
         @options[:desc] ||= @options[:description]
         @options[:desc]&.gsub!(/\n( *)/, "\n  ")
         @formatter = make_formatter

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -17,7 +17,7 @@ module TLAW
         when Hash
           EnumType.new(type)
         else
-          fail ArgumenError, "Undefined type #{type}"
+          fail ArgumentError, "Undefined type #{type}"
         end
       end
 

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -4,12 +4,10 @@ module TLAW
     class Type
       attr_reader :type
 
-      def self.parse(options)
-        type = options[:type]
-
+      def self.parse(type: nil, enum: nil, **)
         case type
         when nil
-          options[:enum] ? EnumType.new(options[:enum]) : Type.new(nil)
+          enum ? EnumType.new(enum) : Type.new(nil)
         when Class
           ClassType.new(type)
         when Symbol

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -80,7 +80,7 @@ module TLAW
     # @private
     class EnumType < Type
       def initialize(enum)
-        @type =
+        super(
           case enum
           when Hash
             enum
@@ -89,6 +89,7 @@ module TLAW
           else
             fail ArgumentError, "Unparseable enum: #{enum.inspect}"
           end
+        )
       end
 
       def possible_values

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -92,14 +92,14 @@ module TLAW
       end
 
       def values
-        type.keys
+        type.keys.map(&:inspect).join(', ')
       end
 
       def validate(value)
         type.key?(value) or
           nonconvertible!(
             value,
-            "is not one of #{type.keys.map(&:inspect).join(', ')}"
+            "is not one of #{values}"
           )
       end
 

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -91,7 +91,7 @@ module TLAW
           end
       end
 
-      def values
+      def possible_values
         type.keys.map(&:inspect).join(', ')
       end
 
@@ -99,7 +99,7 @@ module TLAW
         type.key?(value) or
           nonconvertible!(
             value,
-            "is not one of #{values}"
+            "is not one of #{possible_values}"
           )
       end
 

--- a/spec/tlaw/param_spec.rb
+++ b/spec/tlaw/param_spec.rb
@@ -166,6 +166,12 @@ module TLAW
         end
       end
 
+      describe '#type' do
+        it 'raises an ArgumentError on bad argument' do
+          expect { described_class.new(:p, type: 'hello') }.to raise_error(ArgumentError, 'Undefined type hello')
+        end
+      end
+
       describe '#describe' do
         subject { param.describe }
 

--- a/spec/tlaw/param_spec.rb
+++ b/spec/tlaw/param_spec.rb
@@ -206,6 +206,12 @@ module TLAW
             it { is_expected.to include('Possible values: true, false') }
           end
 
+          context 'hash via type' do
+            let(:param) { described_class.new(:p, type: {true => 'foo', false => 'bar'}) }
+
+            it { is_expected.to include('Possible values: true, false') }
+          end
+
           context 'other enumerable' do
             let(:param) { described_class.new(:p, enum: %w[foo bar]) }
 


### PR DESCRIPTION
This PR fixes two bugs:
- passing a bad `type`
- different behavior between `type: {...}` and `enum: {...}`

It also improve the style and simplifies the code.