### PR TITLE
Range enum

### DIFF
--- a/examples/experimental/tmdb.rb
+++ b/examples/experimental/tmdb.rb
@@ -24,7 +24,7 @@ class TMDB < TLAW::API
 
       endpoint :latest
       endpoint :now_playing do
-        param :page, :to_i, default: 1 # TODO: validate: 1..1000
+        param :page, enum: 1..1000, default: 1
       end
 
       endpoint :upcoming

--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -62,7 +62,7 @@ module TLAW
           name,
           ("[#{doc_type}]" if doc_type),
           description,
-          ("\n  Possible values: #{type.possible_values}" if @options[:enum]),
+          ("\n  Possible values: #{type.possible_values}" if type.respond_to?(:possible_values)),
           ("(default = #{default.inspect})" if default)
         ].compact
           .join(' ')

--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -62,7 +62,7 @@ module TLAW
           name,
           ("[#{doc_type}]" if doc_type),
           description,
-          ("\n  Possible values: #{type.values.map(&:inspect).join(', ')}" if @options[:enum]),
+          ("\n  Possible values: #{type.values}" if @options[:enum]),
           ("(default = #{default.inspect})" if default)
         ].compact
           .join(' ')

--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -62,7 +62,7 @@ module TLAW
           name,
           ("[#{doc_type}]" if doc_type),
           description,
-          ("\n  Possible values: #{type.values}" if @options[:enum]),
+          ("\n  Possible values: #{type.possible_values}" if @options[:enum]),
           ("(default = #{default.inspect})" if default)
         ].compact
           .join(' ')

--- a/lib/tlaw/params/base.rb
+++ b/lib/tlaw/params/base.rb
@@ -12,7 +12,7 @@ module TLAW
       def initialize(name, **options)
         @name = name
         @options = options
-        @type = Type.parse(options)
+        @type = Type.parse(**options)
         @options[:desc] ||= @options[:description]
         @options[:desc]&.gsub!(/\n( *)/, "\n  ")
         @formatter = make_formatter

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -7,7 +7,7 @@ module TLAW
       def self.parse(type: nil, enum: nil, **)
         case type
         when nil
-          enum ? EnumType.new(enum) : Type.new(nil)
+          parse_enum(enum)
         when Class
           ClassType.new(type)
         when Symbol
@@ -16,6 +16,17 @@ module TLAW
           EnumType.new(type)
         else
           fail ArgumentError, "Undefined type #{type}"
+        end
+      end
+
+      def self.parse_enum(enum)
+        case enum
+        when Range
+          RangeType.new(enum)
+        when nil
+          Type.new(nil)
+        else
+          EnumType.new(enum)
         end
       end
 
@@ -99,6 +110,18 @@ module TLAW
 
       def _convert(value)
         type[value]
+      end
+    end
+
+    # @private
+    class RangeType < Type
+      def possible_values
+        type.inspect
+      end
+
+      def validation_error(value)
+        return 'is not an Integer' if type.begin.is_a?(Integer) && !value.is_a?(Integer)
+        "is not in #{possible_values}" unless type.cover?(value)
       end
     end
   end

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -17,7 +17,7 @@ module TLAW
         when Hash
           EnumType.new(type)
         else
-          fail ArgumenError, "Undefined type #{type}"
+          fail ArgumentError, "Undefined type #{type}"
         end
       end
 

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -4,12 +4,10 @@ module TLAW
     class Type
       attr_reader :type
 
-      def self.parse(options)
-        type = options[:type]
-
+      def self.parse(type: nil, enum: nil, **)
         case type
         when nil
-          options[:enum] ? EnumType.new(options[:enum]) : Type.new(nil)
+          enum ? EnumType.new(enum) : Type.new(nil)
         when Class
           ClassType.new(type)
         when Symbol

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -80,7 +80,7 @@ module TLAW
     # @private
     class EnumType < Type
       def initialize(enum)
-        @type =
+        super(
           case enum
           when Hash
             enum
@@ -89,6 +89,7 @@ module TLAW
           else
             fail ArgumentError, "Unparseable enum: #{enum.inspect}"
           end
+        )
       end
 
       def possible_values

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -92,14 +92,14 @@ module TLAW
       end
 
       def values
-        type.keys
+        type.keys.map(&:inspect).join(', ')
       end
 
       def validate(value)
         type.key?(value) or
           nonconvertible!(
             value,
-            "is not one of #{type.keys.map(&:inspect).join(', ')}"
+            "is not one of #{values}"
           )
       end
 

--- a/lib/tlaw/params/type.rb
+++ b/lib/tlaw/params/type.rb
@@ -91,7 +91,7 @@ module TLAW
           end
       end
 
-      def values
+      def possible_values
         type.keys.map(&:inspect).join(', ')
       end
 
@@ -99,7 +99,7 @@ module TLAW
         type.key?(value) or
           nonconvertible!(
             value,
-            "is not one of #{values}"
+            "is not one of #{possible_values}"
           )
       end
 

--- a/spec/tlaw/param_set_spec.rb
+++ b/spec/tlaw/param_set_spec.rb
@@ -133,7 +133,7 @@ module TLAW
             |@param kv2 [#to_i]
             |@param kv1 [Time]
             |@param kv3
-            |  Possible values: 1, 2, 3, 4, 5 (default = 3)
+            |  Possible values: 1..5 (default = 3)
           }.unindent }
         end
       end

--- a/spec/tlaw/param_spec.rb
+++ b/spec/tlaw/param_spec.rb
@@ -45,7 +45,7 @@ module TLAW
           end
         end
 
-        context 'enum' do
+        context 'hash enum' do
           let(:param) { described_class.new(:p, enum: {true => 'yes', false => 'no'}) }
 
           context 'when included' do
@@ -56,6 +56,50 @@ module TLAW
 
           context 'when not' do
             let(:value) { 'foo' }
+
+            its_block { is_expected.to raise_error Nonconvertible }
+          end
+        end
+
+        context 'integer enum' do
+          let(:param) { described_class.new(:p, enum: 1..100) }
+
+          context 'when included' do
+            let(:value) { 42 }
+
+            it { is_expected.to eq 42 }
+          end
+
+          context 'when not an integer' do
+            let(:value) { 42.5 }
+
+            its_block { is_expected.to raise_error Nonconvertible }
+          end
+
+          context 'when not in range' do
+            let(:value) { 0 }
+
+            its_block { is_expected.to raise_error Nonconvertible }
+          end
+        end
+
+        context 'float enum' do
+          let(:param) { described_class.new(:p, enum: 0.0..1.0) }
+
+          context 'when included' do
+            let(:value) { 0.42 }
+
+            it { is_expected.to eq 0.42 }
+          end
+
+          context 'when is an integer in range' do
+            let(:value) { 0 }
+
+            it { is_expected.to eq 0 }
+          end
+
+          context 'when not in range' do
+            let(:value) { 2.0 }
 
             its_block { is_expected.to raise_error Nonconvertible }
           end
@@ -210,6 +254,12 @@ module TLAW
             let(:param) { described_class.new(:p, type: {true => 'foo', false => 'bar'}) }
 
             it { is_expected.to include('Possible values: true, false') }
+          end
+
+          context 'range' do
+            let(:param) { described_class.new(:p, enum: 1..100) }
+
+            it { is_expected.to include('Possible values: 1..100') }
           end
 
           context 'other enumerable' do

--- a/spec/tlaw/param_spec.rb
+++ b/spec/tlaw/param_spec.rb
@@ -166,6 +166,12 @@ module TLAW
         end
       end
 
+      describe '#type' do
+        it 'raises an ArgumentError on bad argument' do
+          expect { described_class.new(:p, type: 'hello') }.to raise_error(ArgumentError, 'Undefined type hello')
+        end
+      end
+
       describe '#describe' do
         subject { param.describe }
 

--- a/spec/tlaw/param_spec.rb
+++ b/spec/tlaw/param_spec.rb
@@ -206,6 +206,12 @@ module TLAW
             it { is_expected.to include('Possible values: true, false') }
           end
 
+          context 'hash via type' do
+            let(:param) { described_class.new(:p, type: {true => 'foo', false => 'bar'}) }
+
+            it { is_expected.to include('Possible values: true, false') }
+          end
+
           context 'other enumerable' do
             let(:param) { described_class.new(:p, enum: %w[foo bar]) }
 


### PR DESCRIPTION
This PR improves handling of `param :foo, enum: 1..1000`. It also allows float enums.

This builds on #21; only the last commit is new.

Note: it's not clear to me why the API allows `type: {a: 1}`, `enum: {a: 1}` and `enum: 1..42` but not `type: 1..42`. I find this inconsistent and would suggest to either allow it, or forbid `type: {...}`. This PR doesn't address this.
